### PR TITLE
add a SCM rockspec + remove dependency on luanet.h

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ LIB=		websocket
 LUAVER=		`lua -v 2>&1 | cut -c 5-7`
 
 CFLAGS+=	-O3 -Wall -fPIC -I/usr/include -I/usr/include/lua${LUAVER} \
-		-I../net -D_GNU_SOURCE
+		-D_GNU_SOURCE
 LDADD+=		-L/usr/lib -lssl -lcrypto
 
 LIBDIR=		/usr/lib/lua/${LUAVER}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LOCALBASE=	/usr/local
 .endif
 
 NOLINT=	1
-CFLAGS+=	-I${LOCALBASE}/include -I../net
+CFLAGS+=	-I${LOCALBASE}/include
 
 LIBDIR=		${LOCALBASE}/lib/lua/5.2
 

--- a/luawebsocket-scm-1.rockspec
+++ b/luawebsocket-scm-1.rockspec
@@ -4,7 +4,7 @@ source = {
    url = "git://github.com/mbalmer/luawebsocket"
 }
 description = {
-   summary = "Network access for Lua",
+   summary = "A WebSocket implementation for Lua, written in C",
    homepage = "http://github.com/mbalmer/luawebsocket",
    license = "3-clause BSD",
 }

--- a/luawebsocket-scm-1.rockspec
+++ b/luawebsocket-scm-1.rockspec
@@ -1,0 +1,30 @@
+package = "luawebsocket"
+version = "scm-1"
+source = {
+   url = "git://github.com/mbalmer/luawebsocket"
+}
+description = {
+   summary = "Network access for Lua",
+   homepage = "http://github.com/mbalmer/luawebsocket",
+   license = "3-clause BSD",
+}
+dependencies = {
+   "lua >= 5.1, < 5.3"
+}
+external_dependencies = {
+   OPENSSL = {
+      header = "openssl/ssl.h",
+      library = "ssl"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+      websocket = {
+         sources = {"base64.c", "websocket.c", "luawebsocket.c"},
+         libraries = {"ssl", "crypto"},
+         incdirs = {"$(OPENSSL_INCDIR)"},
+         libdirs = {"$(OPENSSL_LIBDIR)"}
+      }
+   }
+}

--- a/luawebsocket.c
+++ b/luawebsocket.c
@@ -42,7 +42,6 @@
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 
-#include "luanet.h"
 #include "luawebsocket.h"
 
 #include "websocket.h"


### PR DESCRIPTION
This removes the inclusion of `luanet.h` in `luawebsocket.c`. I don't think anything from that header was used at all in the C file and not requiring it makes the build easier. If it was needed for some reason I missed, please do not merge!